### PR TITLE
fix error for certain properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,6 +156,11 @@ function getComponentAttributes(component) {
 }
 function getAttributeValues(attr) {
     const value = attr.type?.text;
+
+    if (!value) {
+      return [];
+    }
+
     return (value.includes("|") ? value.split("|") : value.split(","))
         .filter((type) => !EXCLUDED_TYPES.includes(type.trim()))
         .map((type) => {


### PR DESCRIPTION
I have two properties that are both defined like this:

```ts
/**
 * The length of time, in milliseconds, the alert will show before closing itself. If the user interacts with
 * the alert before it closes (e.g. moves the mouse over it), the timer will restart. Defaults to `Infinity`.
 */
@property({ type: Number }) duration = Infinity;
```

When parsing attribute values, the following error is thrown:

```
Error:

[cem-plugin-vs-code-custom-data-generator]: Looks like you've hit an error in third party plugin: cem-plugin-vs-code-custom-data-generator. Please try to create a minimal reproduction and inform the author of the cem-plugin-vs-code-custom-data-generator plugin.

 TypeError: Cannot read properties of undefined (reading 'includes')
    at getAttributeValues (file:///.../shoelace/node_modules/cem-plugin-vs-code-custom-data-generator/index.js:164:19)
    at file:///.../shoelace/node_modules/cem-plugin-vs-code-custom-data-generator/index.js:152:21

[truncated for clarity]
```

Here's a dump of the attribute that causes it:

```js
{
  name: 'duration',
  default: 'Infinity',
  description: 'The length of time, in milliseconds, the alert will show before closing itself. If the user interacts with\n' +
    'the alert before it closes (e.g. moves the mouse over it), the timer will restart. Defaults to `Infinity`.',
  resolveInitializer: { module: 'src/components/alert/alert.ts' },
  fieldName: 'duration'
}
```

As you can see, there is no `type` property, resulting in the error shown above when [this line runs](https://github.com/break-stuff/cem-plugin-vs-code-custom-data-generator/blob/9d511c500da657e675600bff2bf154c3d3ee478f/index.js#L158).

This PR fixes the error, but I'm wondering if there's an even better way to improve it. Let me know what you think!