### PR TITLE
Allow users to skip writing html/css files via config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog 
 
+## Unreleased
+
+- Added the ability to skip writing data files [#6](https://github.com/break-stuff/cem-plugin-vs-code-custom-data-generator/pull/6)
+- Fixed a bug that caused the plugin to error out when numeric properties default to `Infinity` [#4](https://github.com/break-stuff/cem-plugin-vs-code-custom-data-generator/pull/4)
+- Fixed a bug that caused CSS parts to be labeled as properties [#5](https://github.com/break-stuff/cem-plugin-vs-code-custom-data-generator/pull/5)
+
 ## 1.0.1
 
 - Add license

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,9 @@
 import { Plugin } from "@custom-elements-manifest/analyzer";
 
 export interface Options {
-  /** The filename to write HTML data to (without path). Set to `undefined` to skip writing this file. Default: `"vscode.html-custom-data.json"` */
+  /** The filename to write HTML data to (without path). Set to `null` to skip writing this file. Default: `"vscode.html-custom-data.json"` */
   htmlFilename?: string;
-  /** The filename to write CSS data to (without path). Set to `undefined` to skip writing this file. Default: `"vscode.css-custom-data.json"` */
+  /** The filename to write CSS data to (without path). Set to `null` to skip writing this file. Default: `"vscode.css-custom-data.json"` */
   cssFilename?: string;
   /** Path to output directory */
   outdir?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,15 @@
 import { Plugin } from "@custom-elements-manifest/analyzer";
 
 export interface Options {
-  /** path to output directory */
+  /** The filename to write HTML data to (without path). Set to `undefined` to skip writing this file. Default: `"vscode.html-custom-data.json"` */
+  htmlFilename?: string;
+  /** The filename to write CSS data to (without path). Set to `undefined` to skip writing this file. Default: `"vscode.css-custom-data.json"` */
+  cssFilename?: string;
+  /** Path to output directory */
   outdir?: string;
-  /** name of the file with you component's custom data */
+  /** Name of the file with you component's custom data */
   filename?: string;
-  /** class names of any components you would like to exclude from the custom data */
+  /** Class names of any components you would like to exclude from the custom data */
   exclude?: string[];
   /** The property name from the component object constructed by the CEM Analyzer */
   descriptionSrc?: "description" | "summary";

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const defaultLabels = {
     cssProperties: "CSS Properties",
     cssParts: "CSS Parts",
 };
-export function generateCustomData({ outdir = "./", htmlFileName = "vscode.html-custom-data.json", cssFileName = "vscode.css-custom-data.json", exclude = [], descriptionSrc, slotDocs = true, eventDocs = true, cssPropertiesDocs = true, cssPartsDocs = true, labels = {} } = {}) {
+export function generateCustomData({ outdir = "./", htmlFilename = "vscode.html-custom-data.json", cssFilename = "vscode.css-custom-data.json", exclude = [], descriptionSrc, slotDocs = true, eventDocs = true, cssPropertiesDocs = true, cssPartsDocs = true, labels = {} } = {}) {
     return {
         name: "cem-plugin-vs-code-custom-data-generator",
         // @ts-ignore
@@ -25,8 +25,8 @@ export function generateCustomData({ outdir = "./", htmlFileName = "vscode.html-
                 "\u001b[0m");
             config = {
                 exclude,
-                htmlFileName,
-                cssFileName,
+                htmlFilename,
+                cssFilename,
                 outdir,
                 descriptionSrc,
                 slotDocs,
@@ -123,9 +123,15 @@ function getDescription(component) {
 function generateCustomDataFile(customElementsManifest) {
     createOutdir();
     const tags = getTagList(customElementsManifest);
-    const cssPropertied = getPropertyList(customElementsManifest);
-    saveFile(config.outdir, config.htmlFileName, getCustomHtmlDataFileContents(tags));
-    saveFile(config.outdir, config.cssFileName, getCustomCssDataFileContents(cssPropertied));
+    const cssProperties = getPropertyList(customElementsManifest);
+
+    if (config.htmlFilename) {
+      saveFile(config.outdir, config.htmlFilename, getCustomHtmlDataFileContents(tags));
+    }
+
+    if (config.cssFilename) {
+      saveFile(config.outdir, config.cssFilename, getCustomCssDataFileContents(cssProperties));
+    }
 }
 function createOutdir() {
     if (config.outdir !== "./" && !fs.existsSync(config.outdir)) {
@@ -189,8 +195,8 @@ function getSlotDocs(component) {
         ?.map((slot) => `- ${slot.name ? `**${slot.name}**` : "_default_"} - ${slot.description}`)
         .join("\n");
 }
-function saveFile(outdir, fileName, contents) {
-    fs.writeFileSync(path.join(outdir, fileName), prettier.format(contents, { parser: "json" }));
+function saveFile(outdir, filename, contents) {
+    fs.writeFileSync(path.join(outdir, filename), prettier.format(contents, { parser: "json" }));
 }
 function getCustomHtmlDataFileContents(tags) {
     return `{


### PR DESCRIPTION
I'm not interested in generating a CSS data file at this time, but couldn't find a way to skip it. The simplest way to allow this is by exposing `cssFilename` and `htmlFilename` as config options. The defaults remain unchanged, but you can configure and/or disable them by setting the value to `null` now:

```ts
// Default behavior is unchanged
generateCustomData()

// Custom config gives us more control
generateCustomData({
  cssFileName: null, // CSS data will not be written
  htmlFileName: 'html-data.json' // HTML will be written to a custom filename `[outdir]/html-data.json`
})
```

Since this introduces two new config vars to the public API, I understand if you'd prefer to approach it differently. For example, using something like `skipHTML / skipCSS`. Of course, this is less flexible because it doesn't offer a way to customize filenames. Anyways, let me know what your thoughts are regarding this and I'll be happy to update the PR to your liking.

Aside: I also corrected a typo in a couple variables, e.g. `fileName` => `filename`. In hindsight, I realize both "filename" and "file name" are technically correct, so this is an opinionated change that you're welcome to revert!